### PR TITLE
Rename Integration API property 'entrypoint' to support change in Astro v4

### DIFF
--- a/src/integration/integration.ts
+++ b/src/integration/integration.ts
@@ -120,7 +120,7 @@ export function i18n(userI18nConfig: UserI18nConfig): AstroIntegration {
               continue;
             }
 
-            const entryPoint =
+            const entrypoint =
               command === "build"
                 ? path.join(pagesPathTmp[locale], relativePath, parsedPath.base)
                 : path.join(pagesPath, relativePath, parsedPath.base);
@@ -136,7 +136,8 @@ export function i18n(userI18nConfig: UserI18nConfig): AstroIntegration {
             );
 
             injectRoute({
-              entryPoint,
+              entryPoint: entrypoint, // fallback for Astro v3
+              entrypoint,
               pattern,
             });
           }


### PR DESCRIPTION
Astro v4 rename injectRoute's argument property `entryPoint` to `entrypoint`.
https://docs.astro.build/en/guides/upgrade-to/v4/#renamed-entrypoint-integrations-api

To support both v3 and v4 we can pass both `entryPoint` and `entrypoint`.